### PR TITLE
feat: add checkdigit validation for aba routing numbers

### DIFF
--- a/src/__tests__/routing-number.ts
+++ b/src/__tests__/routing-number.ts
@@ -18,6 +18,7 @@ describe("routingNumber", () => {
       expect(routingNumber(value)).toEqual({
         isValid: false,
         isPotentiallyValid: false,
+        isCheckDigitValid: false,
       });
     });
   });
@@ -37,6 +38,7 @@ describe("routingNumber", () => {
       expect(routingNumber(value)).toEqual({
         isValid: false,
         isPotentiallyValid: true,
+        isCheckDigitValid: false,
       });
     });
   });
@@ -46,6 +48,7 @@ describe("routingNumber", () => {
       expect(routingNumber(value)).toEqual({
         isValid: true,
         isPotentiallyValid: true,
+        isCheckDigitValid: true,
       });
     });
   });
@@ -55,6 +58,7 @@ describe("routingNumber", () => {
       expect(routingNumber(value)).toEqual({
         isValid: false,
         isPotentiallyValid: false,
+        isCheckDigitValid: false,
       });
     });
   });
@@ -70,6 +74,7 @@ describe("routingNumber", () => {
       expect(routingNumber(value)).toEqual({
         isValid: false,
         isPotentiallyValid: false,
+        isCheckDigitValid: false,
       });
     });
   });

--- a/src/routing-number.ts
+++ b/src/routing-number.ts
@@ -1,5 +1,5 @@
 import routingNumberList from "./routing-number-list";
-import type { BankValidity } from "./types";
+import type { RoutingNumberValidity } from "./types";
 
 const allowedRoutingNumbers = routingNumberList.reduce((result, number) => {
   result[number] = true;
@@ -7,19 +7,49 @@ const allowedRoutingNumbers = routingNumberList.reduce((result, number) => {
   return result;
 }, Object.create(null));
 
-export default function (value: string | unknown): BankValidity {
+export default function (value: string | unknown): RoutingNumberValidity {
   if (typeof value !== "string") {
     return {
       isValid: false,
       isPotentiallyValid: false,
+      isCheckDigitValid: false,
     };
   }
 
   const isValid = value in allowedRoutingNumbers;
   const isPotentiallyValid = /^\d{0,8}$/.test(value);
+  const isCheckDigitValid = getIsCheckDigitValid(value);
 
   return {
     isValid,
     isPotentiallyValid: isValid || isPotentiallyValid,
+    isCheckDigitValid,
   };
 }
+
+/**
+ * reference: https://en.wikipedia.org/wiki/ABA_routing_transit_number#Check_digit
+ * @param abaRoutingNumber an ABA routing number to be checked
+ * @returns whether check digit of the ABA routing number is valid
+ */
+const getIsCheckDigitValid = (abaRoutingNumber: string) => {
+  try {
+    if (!/^\d+$/.test(abaRoutingNumber)) return false;
+    if (abaRoutingNumber.length !== 9) return false;
+
+    const d = abaRoutingNumber.split("").map((digit) => parseInt(digit, 10));
+
+    const res =
+      // prettier-ignore
+      (
+        (3 * (d[0] + d[3] + d[6])) +
+        (7 * (d[1] + d[4] + d[7])) +
+        (1 * (d[2] + d[5] + d[8]))
+      )
+            % 10 === 0;
+
+    return res;
+  } catch (e) {
+    return false;
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,7 @@ export type BankValidity = {
   isValid: boolean;
   isPotentiallyValid: boolean;
 };
+
+export type RoutingNumberValidity = BankValidity & {
+  isCheckDigitValid: boolean;
+};


### PR DESCRIPTION
An alternative to #29 that adds an additional property to the routing number validation specifically for the check digit validation.